### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -22,7 +22,7 @@ setServo	KEYWORD2
 
 init7seg	KEYWORD2
 displayNumber	KEYWORD2
-displayText KEYWORD2
+displayText	KEYWORD2
 displayBytes	KEYWORD2
 clearDisplay	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords